### PR TITLE
README Enhancements (GitHub actions status badges)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,9 @@
 
 [![License: MIT][mit_license]][mit_license_link]
 
-<div align="center">
-
 | main  |   |  | develop  |   |
 |:---:|:---:|:---:|:---:|:---:|
 | [![Main Tests][main_tests]][main_tests_link] | [![Main Publish][main_publish]][main_publish_link] |  | [![Develop Tests][develop_tests]][develop_tests_link] | [![Develop Publish][develop_publish]][develop_publish_link] |
-
-</div>
 
 <div align="center">
 <img src="https://github.com/ksylvan/pyhatchery/blob/main/docs/hatchery_logo.jpg?raw=true" alt="cute snake hatching" width="267" height="200">

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # PyHatchery 🐍🥚
 
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Run Tests](https://github.com/ksylvan/pyhatchery/actions/workflows/tests.yml/badge.svg)](https://github.com/ksylvan/pyhatchery/actions/workflows/tests.yml)
+[![Build and Publish](https://github.com/ksylvan/pyhatchery/actions/workflows/publish.yml/badge.svg)](https://github.com/ksylvan/pyhatchery/actions/workflows/publish.yml)
+
 <div align="center">
 <img src="https://github.com/ksylvan/pyhatchery/blob/main/docs/hatchery_logo.jpg?raw=true" alt="cute snake hatching" width="267" height="200">
 </div>

--- a/README.md
+++ b/README.md
@@ -1,8 +1,14 @@
 # PyHatchery 🐍🥚
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Run Tests](https://github.com/ksylvan/pyhatchery/actions/workflows/tests.yml/badge.svg)](https://github.com/ksylvan/pyhatchery/actions/workflows/tests.yml)
-[![Build and Publish](https://github.com/ksylvan/pyhatchery/actions/workflows/publish.yml/badge.svg)](https://github.com/ksylvan/pyhatchery/actions/workflows/publish.yml)
+[![License: MIT][mit_license]][mit_license_link]
+
+<div align="center">
+
+| main  |   |  | develop  |   |
+|:---:|:---:|:---:|:---:|:---:|
+| [![Main Tests][main_tests]][main_tests_link] | [![Main Publish][main_publish]][main_publish_link] |  | [![Develop Tests][develop_tests]][develop_tests_link] | [![Develop Publish][develop_publish]][develop_publish_link] |
+
+</div>
 
 <div align="center">
 <img src="https://github.com/ksylvan/pyhatchery/blob/main/docs/hatchery_logo.jpg?raw=true" alt="cute snake hatching" width="267" height="200">
@@ -119,7 +125,17 @@ Generated projects will also include a personalized MIT License by default.
 Copyright (c) 2025, [Kayvan Sylvan](mailto:kayvan@sylvan.com)
 
 ---
-[hatchling_url]: https://hatch.pypa.io/latest/
 [astral-uv]: https://github.com/astral-sh/uv
-[project_brief]: ./docs/project_brief.md
 [contributing]: ./docs/contributing.md
+[develop_publish_link]: https://github.com/ksylvan/pyhatchery/actions/workflows/publish.yml?branch=develop
+[develop_publish]: https://github.com/ksylvan/pyhatchery/actions/workflows/publish.yml/badge.svg?branch=develop
+[develop_tests_link]: https://github.com/ksylvan/pyhatchery/actions/workflows/tests.yml?branch=develop
+[develop_tests]: https://github.com/ksylvan/pyhatchery/actions/workflows/tests.yml/badge.svg?branch=develop
+[hatchling_url]: https://hatch.pypa.io/latest/
+[main_publish_link]: https://github.com/ksylvan/pyhatchery/actions/workflows/publish.yml
+[main_publish]: https://github.com/ksylvan/pyhatchery/actions/workflows/publish.yml/badge.svg
+[main_tests_link]: https://github.com/ksylvan/pyhatchery/actions/workflows/tests.yml
+[main_tests]: https://github.com/ksylvan/pyhatchery/actions/workflows/tests.yml/badge.svg
+[mit_license_link]: https://opensource.org/licenses/MIT
+[mit_license]: https://img.shields.io/badge/License-MIT-yellow.svg
+[project_brief]: ./docs/project_brief.md

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Happy hacking!!!
 
 PyHatchery creates projects based on its embedded template structure. This includes a standard layout for Python projects, such as:
 
-- `your_project_name/`: The main package directory.
+- `src/your_project_name/`: The main package directory.
 - `tests/`: For your unit and integration tests.
 - `docs/`: For project documentation.
 - `pyproject.toml`: Pre-configured for `uv`, `hatchling`, `ruff`, `pylint`, and your project metadata.

--- a/src/pyhatchery/__about__.py
+++ b/src/pyhatchery/__about__.py
@@ -1,3 +1,3 @@
 "Version information for pyhatchery."
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"


### PR DESCRIPTION
# README Enhancements (GitHub actions status badges)

## Summary
This PR enhances the README.md file with status badges and clarifies the project structure documentation. It also bumps the package version from 0.5.0 to 0.5.1.

## Files Changed

### 1. README.md
- Added MIT license badge at the top of the README
- Added CI/CD status badges for both main and develop branches
- Corrected the project structure documentation to specify `src/your_project_name/` as the main package directory
- Reorganized and expanded reference links at the bottom of the document

### 2. src/pyhatchery/__about__.py
- Bumped version from 0.5.0 to 0.5.1

## Reason for Changes
These changes improve the project documentation by:
1. Making it easier for users to see the build status of both main and develop branches
2. Clearly indicating the MIT license status
3. Correcting the documentation to accurately reflect the src-layout that PyHatchery generates
4. Incrementing the version number for this minor documentation update

## Impact of Changes
- Improved visibility of project status through badges
- More accurate documentation of the generated project structure
- Better organization of reference links
- New version release (0.5.1)

## Test Plan
The changes are primarily documentation-based and don't affect functionality. The version bump follows semantic versioning principles for a documentation update.

## Additional Notes
The badges are configured to link directly to the GitHub Actions workflows, making it easy for users to check build status details.