### PR TITLE
Code Cleanup and Version Bump

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,6 +40,8 @@ jobs:
           uv run pylint .
       - name: Run tests
         run: uv run pytest -v
+      - name: Run test coverage
+        run: make coverage
 
   check_pr_source:
     name: Check PR Source Branch

--- a/.ruff.toml  # Modify to ensure BLE001 is in [lint].select or [lint].extend-select
+++ b/.ruff.toml  # Modify to ensure BLE001 is in [lint].select or [lint].extend-select
@@ -1,8 +1,0 @@
-[ruff]
-select = ["BLE001"]
-
-[src/pyhatchery/example_broad_except.py]
-try:
-    pass
-except Exception:
-    pass

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -12,7 +12,20 @@
 		{
 			"label": "Run Test Suite",
 			"type": "shell",
-			"command": "cd ${workspaceFolder} && uv run pytest -v",
+			"command": "cd ${workspaceFolder} && make test",
+			"group": {
+				"kind": "test",
+				"isDefault": true
+			},
+			"problemMatcher": ["$python"],
+			"presentation": {
+				"reveal": "always"
+			}
+		},
+		{
+			"label": "Run Test Coverage",
+			"type": "shell",
+			"command": "cd ${workspaceFolder} && make coverage",
 			"group": {
 				"kind": "test",
 				"isDefault": true

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,29 @@
+# Convenience Makefile for pyhatchery
+#
+# This Makefile is used to automate common tasks for the pyhatchery project.
+# It provides a simple interface for running tests, and generating coverage reports.
+
+.PHONY: bootstrap test coverage coverage-html
+
+COVERAGE_FAIL_UNDER := 80
+COVERAGE_SRC := src/pyhatchery
+
+bootstrap:
+	# This will remove and re-create the virtual environment,
+	# installing all dependencies.
+	./bootstrap/setup.sh -F
+
+test:
+	uv run pytest -v
+
+coverage:
+	uv run pytest -v --cov=$(COVERAGE_SRC) \
+		-ra -q \
+		--cov-report=term-missing \
+		--cov-fail-under=$(COVERAGE_FAIL_UNDER)
+
+coverage-html:
+	# This will generate an HTML coverage report.
+	uv run pytest --cov=$(COVERAGE_SRC) \
+		--cov-report=html:coverage_html \
+		--cov-fail-under=$(COVERAGE_FAIL_UNDER)

--- a/docs/coding-standards.md
+++ b/docs/coding-standards.md
@@ -48,22 +48,22 @@ The following high-level patterns and decisions, as detailed in `docs/architectu
   * **Docstrings:** All public modules, classes, functions, and methods must have comprehensive docstrings. Google Python Style Docstrings are preferred for consistency.
     * Example:
 
-            ```python
-            def my_function(param1: str, param2: int) -> bool:
-                """Does something interesting.
+    ```python
+    def my_function(param1: str, param2: int) -> bool:
+        """Does something interesting.
 
-                Args:
-                    param1: The first parameter, a string.
-                    param2: The second parameter, an integer.
+        Args:
+            param1: The first parameter, a string.
+            param2: The second parameter, an integer.
 
-                Returns:
-                    True if successful, False otherwise.
+        Returns:
+            True if successful, False otherwise.
 
-                Raises:
-                    ValueError: If param1 is invalid.
-                """
-                # ...
-            ```
+        Raises:
+            ValueError: If param1 is invalid.
+        """
+        # ...
+    ```
 
   * **Inline Comments:** Use inline comments (`#`) to explain complex or non-obvious sections of code. Avoid commenting on obvious code.
   * **TODO/FIXME Comments:** Use `TODO:` for planned enhancements and `FIXME:` for known issues that need correction. Include a brief explanation.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -35,11 +35,14 @@ you open your fork of the project (see the `.vscode/tasks.json` file)
 
 5. **Make changes:** Implement your fix or feature.
 
-6. **Test your changes:** Run the test suite using `pytest`. You can also use the VS Code task "Run Test Suite". Tests are automatically run via GitHub Actions (`tests.yml`) when you open a pull request.
+6. **Test your changes:** Run the test suite using `pytest`. You can also use the VS Code task "Run Test Suite". Tests are automatically run via GitHub Actions (`tests.yml`) when you open a pull request. Use the Makefile to run both `pytest` and `pytest-cov`.
 
     ```bash
-    uv run pytest -v
+    make test
+    make coverage
     ```
+
+    You can also run `make coverage-html` and then examine the detailed coverage report by opening `./coverage_html/index.html` in your browser.
 
 7. **Check code style:** Ensure your code adheres to the project's style guidelines by running the linters (`ruff` and `pylint`). You can also use the VS Code task "Run Linter". Linting is automatically checked via GitHub Actions (`tests.yml`) when you open a pull request.
 

--- a/docs/tech_stack.md
+++ b/docs/tech_stack.md
@@ -48,5 +48,5 @@
 | Change        | Date       | Version | Description                                     | Author      |
 | ------------- | ---------- | ------- | ----------------------------------------------- | ----------- |
 | Initial draft | 2025-05-09 | 0.1     | Initial draft based on PRD and Project Brief. | 3-Architect |
-| Agile documented | 2025-05-10 | 0.2     | Added note about AI-Agile tasks folder. | Kayvan |
-| pyright added | 2025-05-10 | 0.3    | Pyright and strict typing | Kayvan |
+| Agile documented | 2025-05-10 | 0.2     | Added note about AI-Agile tasks folder. | Kayvan Sylvan |
+| pyright added | 2025-05-10 | 0.3    | Pyright and strict typing | Kayvan Sylvan |

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -15,6 +15,7 @@ The testing strategy for PyHatchery aims to ensure the tool is robust, reliable,
     3. Ensure the CLI (interactive and non-interactive modes) behaves as expected across various inputs and edge cases.
     4. Validate the correctness of the generated project structure and file contents.
     5. Achieve a high level of code coverage for critical components, with an initial target of >90% for core logic.
+    6. Test coverage should be at least 80% (the higher the better)
 
 ## 2. Testing Levels
 
@@ -61,6 +62,12 @@ PyHatchery will employ a multi-layered testing approach:
   * Ensure the final generated project is usable and meets requirements.
   * These are the most comprehensive tests and will be slower than unit or integration tests.
 
+### 2.4 Test Coverage
+
+* **Scope** Ensure the entire PyHatchery code base is being continually tested.
+  * We are using `pytest-cov` for this and it is included in the CI/CD pipeline.
+  * The minimum acceptable test coverage percentage is 80% (we will increase it over time).
+
 ## 3. Specialized Testing Types
 
 * **Static Analysis & Linting:** Covered by `Ruff` and `Pylint` as part of the coding standards and CI checks. These tools help catch potential bugs and style issues early.
@@ -87,3 +94,4 @@ PyHatchery will employ a multi-layered testing approach:
 | Change        | Date       | Version | Description                                          | Author      |
 | ------------- | ---------- | ------- | ---------------------------------------------------- | ----------- |
 | Initial draft | 2025-05-09 | 0.1     | Initial draft of the testing strategy for PyHatchery. | 3-Architect |
+| Test coverage | 2025-05-11 | 0.2     | Add info about test coverage | Kayvan Sylvan |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,15 +26,13 @@ dependencies = ["click>=8.1.8", "python-dotenv>=1.1.0", "requests>=2.32.3"]
 [project.scripts]
 pyhatchery = "pyhatchery.cli:main"
 
-# [tool.hatch.build.targets.wheel.shared-scripts]
-# "pyhatchery/bin/pyhatchery" = "pyhatchery"
-
 [dependency-groups]
 dev = [
     "hatch>=1.14.1",
     "hatchling>=1.27.0",
     "pylint>=3.3.7",
     "pytest>=8.3.5",
+    "pytest-cov>=6.1.1",
     "ruff>=0.11.9",
     "uv>=0.7.3",
 ]

--- a/src/pyhatchery/__about__.py
+++ b/src/pyhatchery/__about__.py
@@ -1,3 +1,3 @@
-"Version information for pyhatchery."
+"""Version information for pyhatchery."""
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"

--- a/src/pyhatchery/cli.py
+++ b/src/pyhatchery/cli.py
@@ -13,7 +13,7 @@ from .components.name_service import (
     derive_python_package_slug,
     has_invalid_characters,
     is_valid_python_package_name,
-    pep503_name_ok,  # Keep this for the initial project name check
+    pep503_name_ok,
     pep503_normalize,
 )
 from .utils.config import str_to_bool
@@ -27,9 +27,7 @@ def _perform_project_name_checks(
     Returns a list of warning messages.
     """
     warnings: list[str] = []
-    # Note: We don't check pep503_name_ok here, as it's done earlier as a blocking check
 
-    # Check PyPI availability
     is_pypi_taken, pypi_error_msg = check_pypi_availability(pypi_slug)
     if pypi_error_msg:
         msg = f"PyPI availability check for '{pypi_slug}' failed: {pypi_error_msg}"
@@ -42,7 +40,6 @@ def _perform_project_name_checks(
         )
         warnings.append(msg)
 
-    # Check Python package slug PEP 8 compliance
     is_python_slug_valid, python_slug_error_msg = is_valid_python_package_name(
         python_slug
     )
@@ -71,37 +68,28 @@ def _handle_new_command(
     args: argparse.Namespace, new_parser: argparse.ArgumentParser, debug_flag: bool
 ) -> int:
     """Handles the 'new' command logic."""
-    if not args.project_name:  # Basic check, more robust validation later
-        # argparse usually handles missing required arguments,
-        # but this is a fallback.
-        # For a missing positional argument, argparse will exit before this.
-        # This explicit check is more for an empty string if argparse allows it.
+    if not args.project_name:
         click.secho("Error: Project name cannot be empty.", fg="red", err=True)
         new_parser.print_help(sys.stderr)
         return 1
 
     project_name = args.project_name
 
-    # First check for invalid characters that should cause immediate rejection
     has_invalid, invalid_error = has_invalid_characters(project_name)
     if has_invalid:
         click.secho(f"Error: {invalid_error}", fg="red", err=True)
         return 1
 
-    # Now derive slugs
     pypi_slug = pep503_normalize(project_name)
 
-    # Check original name format for PEP503 compliance (for warnings)
     is_name_ok, name_error_message = pep503_name_ok(project_name)
     if not is_name_ok:
-        # Other validation failures are just warnings
         click.secho(
             f"Warning: Project name '{project_name}': {name_error_message}",
             fg="yellow",
             err=True,
         )
 
-    # Warn about normalization if needed
     if project_name != pypi_slug:
         click.secho(
             f"Warning: Project name '{project_name}' normalized to '{pypi_slug}'.",
@@ -109,32 +97,26 @@ def _handle_new_command(
             err=True,
         )
 
-    # Use normalized name for internal operations
     project_name = pypi_slug
     python_slug = derive_python_package_slug(project_name)
 
-    # Print derived slugs for debugging/info (optional, can be removed later)
     click.secho(f"Derived PyPI slug: {pypi_slug}", fg="blue", err=True)
     click.secho(f"Derived Python package slug: {python_slug}", fg="blue", err=True)
 
-    # Perform additional name checks and print warnings (non-blocking)
     name_warnings = _perform_project_name_checks(project_name, pypi_slug, python_slug)
 
     # TODO: Add --no-interactive flag check here later (Story 1.3)
     # Look in ai/stories/01.03.story.md
-    # For now, always assume interactive mode if 'new' command is used.
 
     project_details = collect_project_details(project_name, name_warnings)
 
     if project_details is None:
-        # User chose not to proceed after warnings in the wizard
-        return 1  # Or a specific exit code for user cancellation
+        return 1
 
     click.secho(f"Creating new project: {project_name}", fg="green")
     if debug_flag:
         click.secho(f"With details: {project_details}", fg="blue")
 
-    # Actual project creation logic will go here later.
     return 0
 
 
@@ -150,7 +132,7 @@ def main(argv: list[str] | None = None) -> int:
         Exit code for the process.
     """
     parser = argparse.ArgumentParser(
-        prog="pyhatchery",  # Set program name for help messages
+        prog="pyhatchery",
         description="PyHatchery: A Python project scaffolding tool.",
     )
     parser.add_argument(
@@ -165,12 +147,10 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Enable debug mode.",
     )
-    # Subparsers for commands like "new"
     subparsers = parser.add_subparsers(
         dest="command", title="Commands", help="Available commands"
     )
 
-    # "new" command parser
     new_parser = subparsers.add_parser("new", help="Create a new Python project.")
     new_parser.add_argument("project_name", help="The name of the project to create.")
 
@@ -188,14 +168,10 @@ def main(argv: list[str] | None = None) -> int:
     if args.command == "new":
         return _handle_new_command(args, new_parser, debug_flag)
 
-    # If execution reaches here, args.command was not "new".
-    # Check if it was None (meaning no command was provided).
     if args.command is None:
-        # No command was provided
         parser.print_help(sys.stderr)
         return 1
 
-    # Should not be reached if subparsers are set up correctly
     return 1
 
 

--- a/src/pyhatchery/components/config_loader.py
+++ b/src/pyhatchery/components/config_loader.py
@@ -24,12 +24,12 @@ def get_git_config_value(key: str) -> str | None:
             ["git", "config", "--get", key],
             capture_output=True,
             text=True,
-            check=False,  # Don't raise an exception for non-zero exit codes
+            check=False,
         )
         if process_result.returncode == 0:
             return process_result.stdout.strip()
         return None
-    except FileNotFoundError:  # git command not found
+    except FileNotFoundError:
         return None
     except (
         OSError,
@@ -53,15 +53,6 @@ def load_from_env(env_file_path: str = ".env") -> Dict[str, str]:
     """
     env_path = Path(env_file_path)
     if env_path.is_file():
-        # load_dotenv will load them into os.environ and return True if successful
-        # We want to return the dict of variables from the file itself
-        # So, we use dotenv_values which returns a dict
-        # Note: python-dotenv's dotenv_values directly returns the dict
-        # from the .env file without modifying os.environ
-        # For this to work, we need to ensure python-dotenv is installed.
-        # The PRD specifies python-dotenv as a runtime dependency.
-
         loaded_vars = dotenv_values(dotenv_path=env_path)
-        # Filter out None values to match the Dict[str, str] signature
         return {k: v for k, v in loaded_vars.items() if v is not None}
     return {}

--- a/src/pyhatchery/components/http_client.py
+++ b/src/pyhatchery/components/http_client.py
@@ -32,12 +32,12 @@ def check_pypi_availability(package_name: str) -> Tuple[bool | None, str | None]
     """
     url = PYPI_JSON_URL_TEMPLATE.format(package_name=package_name)
     try:
-        response = requests.get(url, timeout=10)  # 10-second timeout
+        response = requests.get(url, timeout=10)
 
         if response.status_code == 200:
-            return True, None  # Name is taken
+            return True, None
         if response.status_code == 404:
-            return False, None  # Name is available
+            return False, None
 
         response_content = response.text[:200] if response.text else "No content"
         error_msg = (
@@ -67,7 +67,6 @@ def check_pypi_availability(package_name: str) -> Tuple[bool | None, str | None]
 
 
 if __name__ == "__main__":
-    # Example usage for quick testing
     names_to_test = [
         "requests",
         "this_package_does_not_exist_and_hopefully_never_will",

--- a/src/pyhatchery/components/interactive_wizard.py
+++ b/src/pyhatchery/components/interactive_wizard.py
@@ -9,7 +9,6 @@ import click
 
 from pyhatchery.components.config_loader import get_git_config_value
 
-# Predefined choices for license and Python versions
 COMMON_LICENSES: List[str] = ["MIT", "Apache-2.0", "GPL-3.0"]
 PYTHON_VERSIONS: List[str] = ["3.10", "3.11", "3.12"]
 DEFAULT_PYTHON_VERSION: str = "3.11"
@@ -59,7 +58,7 @@ def prompt_for_choice(
             raw_selection = input(
                 f"Enter your choice (1-{len(choices)}, default is {default_choice}): "
             ).strip()
-            if not raw_selection:  # User pressed Enter, accept default
+            if not raw_selection:
                 return default_choice
             selection = int(raw_selection)
             if 1 <= selection <= len(choices):
@@ -108,9 +107,6 @@ def collect_project_details(
     details: Dict[str, str] = {}
 
     try:
-        # The default "" for the below fields can not happen, because the exception
-        # will be raised in the prompt_for_value function if the user does not provide
-        # a value and the default is None
         details["author_name"] = (
             prompt_for_value("Author Name", author_name_default) or ""
         )
@@ -146,9 +142,7 @@ def collect_project_details(
 
 
 if __name__ == "__main__":
-    # Example usage for testing the wizard directly
     click.secho("Testing Interactive Wizard...", fg="magenta", bold=True)
-    # Simulate some name warnings
     test_warnings = [
         "The name 'Test-Project' might already be taken on PyPI.",
         "Derived Python package name 'Test_Project' does not follow PEP 8.",

--- a/src/pyhatchery/components/name_service.py
+++ b/src/pyhatchery/components/name_service.py
@@ -5,9 +5,9 @@ import re
 
 _PEP503_VALID_RE = re.compile(
     r"^[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?$",
-    re.IGNORECASE | re.ASCII,  # keeps matching strictly ASCII
+    re.IGNORECASE | re.ASCII,
 )
-_MAX_LEN = 32  # “short”: pragmatic cap
+_MAX_LEN = 32
 
 
 def pep503_normalize(name: str) -> str:
@@ -29,16 +29,9 @@ def pep503_normalize(name: str) -> str:
     Returns:
         str: The PEP 503-compatible normalized slug.
     """
-    # Step 1: Convert the string to lowercase
     name = name.lower()
-
-    # Step 2: Replace any character not in [a-z0-9._-] with a hyphen
     name = re.sub(r"[^a-z0-9._-]+", "-", name)
-
-    # Step 3: Collapse consecutive invalid characters (., _, -) into a single hyphen
     name = re.sub(r"[-_.]+", "-", name)
-
-    # Step 4: Strip leading and trailing hyphens
     name = name.strip("-")
     return name
 
@@ -55,29 +48,20 @@ def derive_python_package_slug(name: str) -> str:
     Returns:
         A string suitable for use as a Python package name.
     """
-    # Replace non-alphanumeric characters (except underscores) with underscores
     slug = re.sub(r"[^a-zA-Z0-9_]", "_", name)
-    # Convert to lowercase
     slug = slug.lower()
-    # Consolidate multiple underscores
     slug = re.sub(r"_+", "_", slug)
-    # Remove leading/trailing underscores
     slug = slug.strip("_")
 
-    # Ensure it's a valid Python identifier
-    if not slug:  # Handle empty string case
+    if not slug:
         return "default_package_name"
-
-    # Check if it's a Python keyword
 
     if keyword.iskeyword(slug):
         return "default_package_name"
 
     if not slug.isidentifier():
-        # If it's not a valid identifier (e.g., starts with a digit)
         if slug[0].isdigit():
             slug = f"p_{slug}"
-        # If still not an identifier, provide a default
         if not slug.isidentifier():
             return "default_package_name"
 
@@ -105,17 +89,11 @@ def is_valid_python_package_name(slug: str) -> tuple[bool, str | None]:
             f"Derived Python package slug '{slug}' is not a valid Python identifier "
             "(e.g., cannot start with a digit or contain hyphens/spaces).",
         )
-    if not slug.islower():  # isidentifier allows uppercase, but PEP 8 wants lowercase
-        # This check might be redundant if derive_python_package_slug
-        # always produces lowercase
+    if not slug.islower():
         return (
             False,
             f"Derived Python package slug '{slug}' should be all lowercase.",
         )
-    # Further check for characters, though isidentifier should cover most.
-    # PEP 8: "modules should have short, all-lowercase names. Underscores can be
-    # used in the module name if it improves readability."
-    # isidentifier() handles a-z, 0-9, _ expectations.
     return True, None
 
 
@@ -146,9 +124,7 @@ def pep503_name_ok(project_name: str) -> tuple[bool, str | None]:
             False,
             f"Project name '{project_name}' is too long (max {_MAX_LEN} chars).",
         )
-    if (
-        project_name.count("_") + project_name.count("-")
-    ) > 2:  # keep names terse/readable
+    if (project_name.count("_") + project_name.count("-")) > 2:
         return False, "Project name contains too many underscores or dashes."
     return True, None
 
@@ -170,7 +146,6 @@ def has_invalid_characters(name: str) -> tuple[bool, str | None]:
             - has_invalid: True if the name contains invalid characters
             - error_message: The invalid characters found, or None if valid
     """
-    # List of characters that should cause immediate rejection
     invalid_chars = "!@#$%^&*+=}{[]|\\/:;\"'<>"
 
     found_invalid = [char for char in invalid_chars if char in name]

--- a/tests/integration/test_project_generation.py
+++ b/tests/integration/test_project_generation.py
@@ -2,9 +2,9 @@
 
 import subprocess
 import sys
-from unittest.mock import MagicMock, patch  # Ensure this import is present
+from unittest.mock import MagicMock, patch
 
-import pytest  # Ensure this import is present
+import pytest
 
 from pyhatchery.__about__ import __version__
 
@@ -20,19 +20,16 @@ def run_cli_command(args: list[str], expected_returncode: int = 0) -> tuple[str,
     Returns:
         A tuple of (stdout, stderr) from the process
     """
-    # Construct the command to run
     cmd: list[str] = [sys.executable, "-m", "pyhatchery"] + args
 
-    # Run the command and capture stdout/stderr
     process = subprocess.run(
         cmd,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,
-        check=False,  # We'll check the return code ourselves
+        check=False,
     )
 
-    # Check the return code
     assert process.returncode == expected_returncode, (
         f"Expected return code {expected_returncode}, got {process.returncode}\n"
         f"stdout: {process.stdout}\n"
@@ -55,9 +52,8 @@ class TestCliIntegration:
         # TODO: Re-enable/adapt with non-interactive mode (Story 1.3).
         # Fails due to wizard input in subprocess.
         project_name = "my_test_project"
-        normalized_name = "my-test-project"  # This is what we expect
+        normalized_name = "my-test-project"
 
-        # Simulate wizard returning some details to allow CLI to proceed
         mock_collect_details.return_value = {
             "author_name": "Integration Test Author",
             "author_email": "integration@test.com",
@@ -70,7 +66,6 @@ class TestCliIntegration:
         stdout, stderr = run_cli_command(["new", project_name])
 
         assert f"Creating new project: {normalized_name}" in stdout
-        # Also check for the "With details" line now
         assert "With details: {'author_name': 'Integration Test Author'" in stdout
         assert "Derived PyPI slug:" in stderr
         assert "Derived Python package slug:" in stderr
@@ -86,7 +81,7 @@ class TestCliIntegration:
         """Test that 'pyhatchery new' with an invalid name shows an error and exits."""
         stdout, stderr = run_cli_command(["new", "invalid!name"], expected_returncode=1)
 
-        assert stdout == ""  # Error message should go to stderr
+        assert stdout == ""
         assert "Error: Project name contains invalid characters" in stderr
         assert "'!'" in stderr
 

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -4,11 +4,6 @@ import re
 
 import pyhatchery
 
-# Semantic Versioning 2.0.0 regex from https://semver.org/
-# This regex is used to validate version strings.
-# Passes versions like "1.0.0", "0.2.1", "1.0.0-alpha", "2.1.0-beta.1+build.123"
-# and respects rules like no leading zeros for numeric identifiers
-# (e.g., "01.0.0" is invalid).
 SEMVER_REGEX = (
     r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
     r"(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)"
@@ -22,19 +17,16 @@ def test_version_attributes():
     Tests that the __version__ attribute is set in the module and
     conforms to semantic versioning norms (SemVer 2.0.0).
     """
-    # Check if the __version__ attribute exists
     assert hasattr(pyhatchery, "__version__"), (
         "The package should have a __version__ attribute."
     )
 
     version = pyhatchery.__version__
 
-    # Check if __version__ is a string
     assert isinstance(version, str), (
         f"The __version__ attribute must be a string, but found type {type(version)}."
     )
 
-    # Check if __version__ conforms to semantic versioning
     assert re.fullmatch(SEMVER_REGEX, version), (
         f"Version '{version}' does not conform to SemVer (X.Y.Z[-pre+build]). "
         f"See https://semver.org for details."

--- a/tests/unit/components/test_config_loader.py
+++ b/tests/unit/components/test_config_loader.py
@@ -4,14 +4,13 @@ Unit tests for the config_loader component.
 
 import subprocess
 from pathlib import Path
-from typing import Callable  # Ensure Callable is imported
+from typing import Callable
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from pyhatchery.components.config_loader import get_git_config_value, load_from_env
 
-# Test data for .env file
 ENV_CONTENT_VALID = """
 AUTHOR_NAME="Test Env Author"
 AUTHOR_EMAIL="env@example.com"
@@ -26,12 +25,10 @@ ENV_CONTENT_EMPTY = ""
 @pytest.fixture(name="temp_env_file")
 def temp_env_file_fixture(
     tmp_path: Path,
-) -> Callable[..., Path]:  # Added return type hint
+) -> Callable[..., Path]:
     """Fixture to create a temporary .env file."""
 
-    def _create_env_file(
-        content: str, filename: str = ".env"
-    ) -> Path:  # Added return type hint
+    def _create_env_file(content: str, filename: str = ".env") -> Path:
         env_file = tmp_path / filename
         env_file.write_text(content)
         return env_file
@@ -63,7 +60,7 @@ class TestGetGitConfigValue:
     def test_get_git_config_value_not_set(self, mock_subprocess_run: MagicMock):
         """Test when the git config value is not set (git command returns non-zero)."""
         mock_process = MagicMock()
-        mock_process.returncode = 1  # Value not set
+        mock_process.returncode = 1
         mock_process.stdout = ""
         mock_subprocess_run.return_value = mock_process
 
@@ -90,22 +87,19 @@ class TestGetGitConfigValue:
 class TestLoadFromEnv:
     """Tests for the load_from_env function."""
 
-    @patch("pyhatchery.components.config_loader.Path")  # Outer patch
-    @patch("pyhatchery.components.config_loader.dotenv_values")  # Inner patch
+    @patch("pyhatchery.components.config_loader.Path")
+    @patch("pyhatchery.components.config_loader.dotenv_values")
     def test_load_from_env_success(
         self,
-        mock_dotenv_values_in_cl: MagicMock,  # Inner patch arg
-        mock_path_in_cl: MagicMock,  # Outer patch arg
-        temp_env_file: Callable[..., Path],  # Using the correct fixture name
+        mock_dotenv_values_in_cl: MagicMock,
+        mock_path_in_cl: MagicMock,
+        temp_env_file: Callable[..., Path],
     ):
         """Test successfully loading variables from an .env file."""
         real_env_file_path_obj = temp_env_file(ENV_CONTENT_VALID)
         real_env_file_path_str = str(real_env_file_path_obj)
 
-        # Configure the mock for Path class instantiation within config_loader
-        # This mock_path_instance will be returned when Path(...) is called
         mock_path_instance = MagicMock(spec=Path)
-        # Crucially, mock the is_file method on this instance
         mock_path_instance.is_file = MagicMock(return_value=True)
         mock_path_in_cl.return_value = mock_path_instance
 
@@ -120,23 +114,22 @@ class TestLoadFromEnv:
 
         mock_path_in_cl.assert_called_once_with(real_env_file_path_str)
         mock_path_instance.is_file.assert_called_once()
-        # dotenv_values should be called with the Path obj created in load_from_env
         mock_dotenv_values_in_cl.assert_called_once_with(dotenv_path=mock_path_instance)
         assert result == expected_loaded_vars
 
-    @patch("pyhatchery.components.config_loader.Path")  # Outer
-    @patch("pyhatchery.components.config_loader.dotenv_values")  # Inner
+    @patch("pyhatchery.components.config_loader.Path")
+    @patch("pyhatchery.components.config_loader.dotenv_values")
     def test_load_from_env_file_not_found(
         self,
-        mock_dotenv_values_in_cl: MagicMock,  # Inner
-        mock_path_in_cl: MagicMock,  # Outer
+        mock_dotenv_values_in_cl: MagicMock,
+        mock_path_in_cl: MagicMock,
         tmp_path: Path,
     ):
         """Test when the .env file does not exist."""
         non_existent_env_file_str = str(tmp_path / "non_existent.env")
 
         mock_path_instance = MagicMock(spec=Path)
-        mock_path_instance.is_file = MagicMock(return_value=False)  # Key for this test
+        mock_path_instance.is_file = MagicMock(return_value=False)
         mock_path_in_cl.return_value = mock_path_instance
 
         result = load_from_env(non_existent_env_file_str)
@@ -146,13 +139,13 @@ class TestLoadFromEnv:
         mock_dotenv_values_in_cl.assert_not_called()
         assert result == {}
 
-    @patch("pyhatchery.components.config_loader.Path")  # Outer
-    @patch("pyhatchery.components.config_loader.dotenv_values")  # Inner
+    @patch("pyhatchery.components.config_loader.Path")
+    @patch("pyhatchery.components.config_loader.dotenv_values")
     def test_load_from_env_empty_file(
         self,
-        mock_dotenv_values_in_cl: MagicMock,  # Inner
-        mock_path_in_cl: MagicMock,  # Outer
-        temp_env_file: Callable[..., Path],  # Using the correct fixture name
+        mock_dotenv_values_in_cl: MagicMock,
+        mock_path_in_cl: MagicMock,
+        temp_env_file: Callable[..., Path],
     ):
         """Test loading from an empty .env file."""
         real_env_file_path_obj = temp_env_file(ENV_CONTENT_EMPTY)
@@ -171,12 +164,12 @@ class TestLoadFromEnv:
         mock_dotenv_values_in_cl.assert_called_once_with(dotenv_path=mock_path_instance)
         assert result == {}
 
-    @patch("pyhatchery.components.config_loader.Path")  # Outer
-    @patch("pyhatchery.components.config_loader.dotenv_values")  # Inner
+    @patch("pyhatchery.components.config_loader.Path")
+    @patch("pyhatchery.components.config_loader.dotenv_values")
     def test_load_from_env_default_path_exists(
         self,
-        mock_dotenv_values_in_cl: MagicMock,  # Inner
-        mock_path_in_cl: MagicMock,  # Outer
+        mock_dotenv_values_in_cl: MagicMock,
+        mock_path_in_cl: MagicMock,
     ):
         """Test loading from default '.env' when it exists."""
         mock_path_instance = MagicMock(spec=Path)
@@ -186,26 +179,26 @@ class TestLoadFromEnv:
         expected_vars_from_dotenv = {"DEFAULT_KEY": "DefaultValue"}
         mock_dotenv_values_in_cl.return_value = expected_vars_from_dotenv
 
-        result = load_from_env()  # Call with default path ".env"
+        result = load_from_env()
 
         mock_path_in_cl.assert_called_once_with(".env")
         mock_path_instance.is_file.assert_called_once()
         mock_dotenv_values_in_cl.assert_called_once_with(dotenv_path=mock_path_instance)
         assert result == expected_vars_from_dotenv
 
-    @patch("pyhatchery.components.config_loader.Path")  # Outer
-    @patch("pyhatchery.components.config_loader.dotenv_values")  # Inner
+    @patch("pyhatchery.components.config_loader.Path")
+    @patch("pyhatchery.components.config_loader.dotenv_values")
     def test_load_from_env_default_path_not_exists(
         self,
-        mock_dotenv_values_in_cl: MagicMock,  # Inner
-        mock_path_in_cl: MagicMock,  # Outer
+        mock_dotenv_values_in_cl: MagicMock,
+        mock_path_in_cl: MagicMock,
     ):
         """Test loading from default '.env' when it does not exist."""
         mock_path_instance = MagicMock(spec=Path)
         mock_path_instance.is_file = MagicMock(return_value=False)
         mock_path_in_cl.return_value = mock_path_instance
 
-        result = load_from_env()  # Call with default path
+        result = load_from_env()
 
         mock_path_in_cl.assert_called_once_with(".env")
         mock_path_instance.is_file.assert_called_once()

--- a/tests/unit/components/test_http_client.py
+++ b/tests/unit/components/test_http_client.py
@@ -14,15 +14,12 @@ class TestHttpClient(unittest.TestCase):
     @patch("pyhatchery.components.http_client.requests.get")
     def test_pypi_name_taken(self, mock_get: MagicMock):
         """Test that a 200 OK response indicates a package name is taken."""
-        # Setup
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_get.return_value = mock_response
 
-        # Execute
         is_taken, error_msg = check_pypi_availability("existing-package")
 
-        # Assert
         self.assertTrue(is_taken)
         self.assertIsNone(error_msg)
         mock_get.assert_called_once_with(
@@ -32,15 +29,12 @@ class TestHttpClient(unittest.TestCase):
     @patch("pyhatchery.components.http_client.requests.get")
     def test_pypi_name_available(self, mock_get: MagicMock):
         """Test that a 404 Not Found response indicates a package name is available."""
-        # Setup
         mock_response = MagicMock()
         mock_response.status_code = 404
         mock_get.return_value = mock_response
 
-        # Execute
         is_taken, error_msg = check_pypi_availability("new-package-name")
 
-        # Assert
         self.assertFalse(is_taken)
         self.assertIsNone(error_msg)
         mock_get.assert_called_once_with(
@@ -50,16 +44,13 @@ class TestHttpClient(unittest.TestCase):
     @patch("pyhatchery.components.http_client.requests.get")
     def test_pypi_api_error(self, mock_get: MagicMock):
         """Test handling of an unexpected status code from PyPI API."""
-        # Setup
         mock_response = MagicMock()
         mock_response.status_code = 500
         mock_response.text = "Internal server error"
         mock_get.return_value = mock_response
 
-        # Execute
         is_taken, error_msg = check_pypi_availability("package-name")
 
-        # Assert
         self.assertIsNone(is_taken)
         self.assertIsNotNone(error_msg)
         self.assertIn("Unexpected status code: 500", str(error_msg))
@@ -71,13 +62,10 @@ class TestHttpClient(unittest.TestCase):
     @patch("pyhatchery.components.http_client.requests.get")
     def test_network_timeout(self, mock_get: MagicMock):
         """Test handling of a network timeout."""
-        # Setup
         mock_get.side_effect = requests.exceptions.Timeout("Connection timed out")
 
-        # Execute
         is_taken, error_msg = check_pypi_availability("package-name")
 
-        # Assert
         self.assertIsNone(is_taken)
         self.assertIsNotNone(error_msg)
         self.assertIn("timed out", str(error_msg))
@@ -88,15 +76,12 @@ class TestHttpClient(unittest.TestCase):
     @patch("pyhatchery.components.http_client.requests.get")
     def test_connection_error(self, mock_get: MagicMock):
         """Test handling of a connection error."""
-        # Setup
         mock_get.side_effect = requests.exceptions.ConnectionError(
             "Could not connect to PyPI"
         )
 
-        # Execute
         is_taken, error_msg = check_pypi_availability("package-name")
 
-        # Assert
         self.assertIsNone(is_taken)
         self.assertIsNotNone(error_msg)
         self.assertIn("connection error", str(error_msg))
@@ -107,15 +92,12 @@ class TestHttpClient(unittest.TestCase):
     @patch("pyhatchery.components.http_client.requests.get")
     def test_general_request_exception(self, mock_get: MagicMock):
         """Test handling of a general request exception."""
-        # Setup
         mock_get.side_effect = requests.exceptions.RequestException(
             "Some other request error"
         )
 
-        # Execute
         is_taken, error_msg = check_pypi_availability("package-name")
 
-        # Assert
         self.assertIsNone(is_taken)
         self.assertIsNotNone(error_msg)
         self.assertIn("unexpected error", str(error_msg))

--- a/tests/unit/components/test_interactive_wizard.py
+++ b/tests/unit/components/test_interactive_wizard.py
@@ -31,7 +31,7 @@ class TestPromptForValue:
     @patch(f"{MODULE_PATH}.input")
     def test_prompt_with_default_user_accepts_default(self, mock_input: MagicMock):
         """Test when a default is provided and user presses Enter (empty input)."""
-        mock_input.return_value = ""  # User presses Enter
+        mock_input.return_value = ""
         result = prompt_for_value("Enter something", "Default Value")
         assert result == "Default Value"
 
@@ -44,16 +44,15 @@ class TestPromptForValue:
         mock_input.assert_called_once_with("Enter something: ")
 
     @patch(f"{MODULE_PATH}.input")
-    @patch(f"{MODULE_PATH}.click")  # To capture click calls for "cannot be empty"
+    @patch(f"{MODULE_PATH}.click")
     def test_prompt_no_default_user_enters_empty_then_value(
         self, mock_click: MagicMock, mock_input: MagicMock
     ):
         """Test no default, user enters empty string then a valid value."""
-        mock_input.side_effect = ["", "User Value"]  # First empty, then value
+        mock_input.side_effect = ["", "User Value"]
         result = prompt_for_value("Enter something")
         assert result == "User Value"
         assert mock_input.call_count == 2
-        # Updated assertion to check for click.secho with fg='red'
         mock_click.secho.assert_called_once_with(
             "This field cannot be empty.", fg="red"
         )
@@ -66,15 +65,14 @@ class TestPromptForChoice:
     default = "Beta"
 
     @patch(f"{MODULE_PATH}.input")
-    @patch(f"{MODULE_PATH}.click")  # To check prompts
+    @patch(f"{MODULE_PATH}.click")
     def test_selects_valid_choice_by_number(
         self, mock_click: MagicMock, mock_input: MagicMock
     ):
         """Test selecting a valid choice by its number."""
-        mock_input.return_value = "1"  # Selects "Alpha"
+        mock_input.return_value = "1"
         result = prompt_for_choice("Choose:", self.choices, self.default)
         assert result == "Alpha"
-        # Check that choices were printed correctly
         expected_calls = [
             call.secho("Choose:", fg="cyan"),
             call.secho("  1. Alpha"),
@@ -83,12 +81,11 @@ class TestPromptForChoice:
             call.secho("  3. Gamma"),
         ]
         mock_click.assert_has_calls(expected_calls, any_order=True)
-        # Updated to check mock_click.method_calls directly
 
     @patch(f"{MODULE_PATH}.input")
     def test_accepts_default_choice_on_enter(self, mock_input: MagicMock):
         """Test accepting the default choice by pressing Enter."""
-        mock_input.return_value = ""  # User presses Enter
+        mock_input.return_value = ""
         result = prompt_for_choice("Choose:", self.choices, self.default)
         assert result == self.default
 
@@ -98,18 +95,11 @@ class TestPromptForChoice:
         self, mock_click: MagicMock, mock_input: MagicMock
     ):
         """Test handling invalid numeric choices before a valid one."""
-        mock_input.side_effect = ["0", "4", "2"]  # Invalid, Invalid, Valid ("Beta")
+        mock_input.side_effect = ["0", "4", "2"]
         result = prompt_for_choice("Choose:", self.choices, self.default)
         assert result == "Beta"
         assert mock_input.call_count == 3
-        # Check that error messages were printed
         error_message = f"Invalid choice. Enter a number from 1 to {len(self.choices)}."
-        # Check error messages were printed for each invalid input.
-        # Skips initial prompt and choice listing.
-        # The number of initial secho calls for prompt and choices:
-        # 1 for prompt_message
-        # 1 for each choice (self.choices)
-        # 1 extra for the default choice's "(default)" part
         initial_secho_calls = 1 + len(self.choices) + 1
         calls_to_check = mock_click.method_calls[initial_secho_calls:]
         assert all(
@@ -123,11 +113,10 @@ class TestPromptForChoice:
         self, mock_click: MagicMock, mock_input: MagicMock
     ):
         """Test handling of non-numeric input before a valid numeric choice."""
-        mock_input.side_effect = ["abc", "3"]  # Invalid, Valid ("Gamma")
+        mock_input.side_effect = ["abc", "3"]
         result = prompt_for_choice("Choose:", self.choices, self.default)
         assert result == "Gamma"
         assert mock_input.call_count == 2
-        # Updated assertion to check for click.secho with fg='red'
         assert (
             call.secho("Invalid input. Please enter a number.", fg="red")
             in mock_click.method_calls
@@ -142,7 +131,7 @@ class TestCollectProjectDetails:
     @patch(f"{MODULE_PATH}.get_git_config_value")
     @patch(f"{MODULE_PATH}.prompt_for_value")
     @patch(f"{MODULE_PATH}.prompt_for_choice")
-    @patch(f"{MODULE_PATH}.input")  # For the "proceed?" prompt
+    @patch(f"{MODULE_PATH}.input")
     def test_collects_all_details_no_warnings(
         self,
         mock_proceed_input: MagicMock,
@@ -151,15 +140,15 @@ class TestCollectProjectDetails:
         mock_get_git_config: MagicMock,
     ):
         """Test collecting all details when there are no name warnings."""
-        mock_get_git_config.side_effect = ["Git User", "git@example.com"]  # name, email
+        mock_get_git_config.side_effect = ["Git User", "git@example.com"]
         mock_prompt_value.side_effect = [
-            "Test Author",  # Author Name (overrides git)
-            "test@example.com",  # Author Email (overrides git)
-            "testuser",  # GitHub Username
-            "A test project",  # Project Description
+            "Test Author",
+            "test@example.com",
+            "testuser",
+            "A test project",
         ]
-        mock_prompt_choice.side_effect = ["MIT", "3.11"]  # License, Python Version
-        mock_proceed_input.return_value = "yes"  # Should not be called if no warnings
+        mock_prompt_choice.side_effect = ["MIT", "3.11"]
+        mock_proceed_input.return_value = "yes"
 
         result = collect_project_details(self.PROJECT_NAME, name_warnings=None)
 
@@ -174,12 +163,12 @@ class TestCollectProjectDetails:
         mock_get_git_config.assert_has_calls([call("user.name"), call("user.email")])
         assert mock_prompt_value.call_count == 4
         assert mock_prompt_choice.call_count == 2
-        mock_proceed_input.assert_not_called()  # No warnings, so no proceed prompt
+        mock_proceed_input.assert_not_called()
 
     @patch(f"{MODULE_PATH}.get_git_config_value")
     @patch(f"{MODULE_PATH}.prompt_for_value")
     @patch(f"{MODULE_PATH}.prompt_for_choice")
-    @patch(f"{MODULE_PATH}.input")  # For the "proceed?" prompt
+    @patch(f"{MODULE_PATH}.input")
     def test_collects_details_with_warnings_user_proceeds(
         self,
         mock_proceed_input: MagicMock,
@@ -189,9 +178,9 @@ class TestCollectProjectDetails:
     ):
         """Test collecting details when warnings exist and user proceeds."""
         warnings = ["Name too short", "Name invalid"]
-        mock_proceed_input.return_value = "yes"  # User proceeds
+        mock_proceed_input.return_value = "yes"
 
-        mock_get_git_config.side_effect = [None, None]  # No git defaults
+        mock_get_git_config.side_effect = [None, None]
         mock_prompt_value.side_effect = [
             "Author From Prompt",
             "email@prompt.com",
@@ -210,13 +199,13 @@ class TestCollectProjectDetails:
             "Ignore warnings and proceed with this name? (yes/no, default: yes): "
         )
 
-    @patch(f"{MODULE_PATH}.input")  # For the "proceed?" prompt
+    @patch(f"{MODULE_PATH}.input")
     def test_exits_if_user_does_not_proceed_after_warnings(
         self, mock_proceed_input: MagicMock
     ):
         """Test that function returns None if user chooses not to proceed."""
         warnings = ["Name conflict"]
-        mock_proceed_input.return_value = "no"  # User does not proceed
+        mock_proceed_input.return_value = "no"
 
         result = collect_project_details(self.PROJECT_NAME, name_warnings=warnings)
         assert result is None
@@ -232,11 +221,8 @@ class TestCollectProjectDetails:
         mock_get_git_config: MagicMock,
     ):
         """Test defaults used if git config missing & prompts accept defaults."""
-        # _prompt_for_value will return its default if input is empty
-        # _prompt_for_choice will return its default if input is empty
-        # Simulate this by having them return expected default values
         mock_prompt_value.side_effect = [
-            "Default Author",  # Assumes _prompt_for_value returns this
+            "Default Author",
             "default@example.com",
             "default_gh",
             "Default Description",
@@ -246,10 +232,6 @@ class TestCollectProjectDetails:
         result = collect_project_details(self.PROJECT_NAME, name_warnings=None)
 
         assert result is not None
-        # The actual default for author/email if git is None and input is empty
-        # depends on how _prompt_for_value handles a None default.
-        # The current _prompt_for_value requires input if default is None.
-        # So, this test setup implies the user *typed* these "Default Author" values.
         assert result["author_name"] == "Default Author"
         assert result["author_email"] == "default@example.com"
         assert result["github_username"] == "default_gh"
@@ -257,20 +239,16 @@ class TestCollectProjectDetails:
         assert result["license"] == DEFAULT_LICENSE
         assert result["python_version_preference"] == DEFAULT_PYTHON_VERSION
 
-        # Check that get_git_config_value was called
         mock_get_git_config.assert_has_calls([call("user.name"), call("user.email")])
 
-        # Check that _prompt_for_value was called for each field
-        # Defaults for author name/email passed to _prompt_for_value would be None.
         expected_prompt_value_calls = [
             call("Author Name", None),
             call("Author Email", None),
-            call("GitHub Username"),  # No default passed
-            call("Project Description"),  # No default passed
+            call("GitHub Username"),
+            call("Project Description"),
         ]
         mock_prompt_value.assert_has_calls(expected_prompt_value_calls)
 
-        # Check that _prompt_for_choice was called for license and python version
         expected_prompt_choice_calls = [
             call("Select License:", COMMON_LICENSES, DEFAULT_LICENSE),
             call("Select Python Version:", PYTHON_VERSIONS, DEFAULT_PYTHON_VERSION),

--- a/tests/unit/components/test_name_service.py
+++ b/tests/unit/components/test_name_service.py
@@ -16,24 +16,14 @@ class TestNameService(unittest.TestCase):
     def test_pep503_normalize(self):
         """Test PEP 503 normalization for various inputs."""
         test_cases = [
-            # (input_name, expected_output)
-            ("my-project", "my-project"),  # No change needed
-            ("My_Project", "my-project"),  # Lowercase, underscore to hyphen
-            ("My.Project", "my-project"),  # Lowercase, period to hyphen
-            (
-                "My__Project..Name",
-                "my-project-name",
-            ),  # Multiple separators to single hyphen
-            (
-                "my-project",
-                "my-project",
-            ),  # No change needed (placeholder test case to match implementation)
-            (
-                "My--Project__Name",
-                "my-project-name",
-            ),  # Multiple separators of same type
-            ("123-PROJECT", "123-project"),  # Start with number, uppercase to lowercase
-            ("PROJECT", "project"),  # All uppercase to lowercase
+            ("my-project", "my-project"),
+            ("My_Project", "my-project"),
+            ("My.Project", "my-project"),
+            ("My__Project..Name", "my-project-name"),
+            ("my-project", "my-project"),
+            ("My--Project__Name", "my-project-name"),
+            ("123-PROJECT", "123-project"),
+            ("PROJECT", "project"),
         ]
 
         for input_name, expected_output in test_cases:
@@ -49,16 +39,15 @@ class TestNameService(unittest.TestCase):
     def test_derive_python_package_slug(self):
         """Test Python package slug derivation for various inputs."""
         test_cases = [
-            # (input_name, expected_output)
-            ("my_package", "my_package"),  # Already valid
-            ("My Package", "my_package"),  # Spaces to underscore
-            ("My-Hyphenated-Package", "my_hyphenated_package"),  # Hyphens to underscore
-            ("123package", "p_123package"),  # Start with digit, prepend p_
-            ("package.name", "package_name"),  # Dots to underscore
-            ("my__package", "my_package"),  # Multiple underscores to single
-            ("_package_", "package"),  # Strip leading/trailing underscores
-            ("", "default_package_name"),  # Empty string gets default
-            ("pass", "default_package_name"),  # Python keyword gets default
+            ("my_package", "my_package"),
+            ("My Package", "my_package"),
+            ("My-Hyphenated-Package", "my_hyphenated_package"),
+            ("123package", "p_123package"),
+            ("package.name", "package_name"),
+            ("my__package", "my_package"),
+            ("_package_", "package"),
+            ("", "default_package_name"),
+            ("pass", "default_package_name"),
         ]
 
         for input_name, expected_output in test_cases:
@@ -74,7 +63,6 @@ class TestNameService(unittest.TestCase):
 
     def test_is_valid_python_package_name(self):
         """Test validation of Python package names against PEP 8 conventions."""
-        # Valid names
         valid_names = [
             "package_name",
             "simple",
@@ -92,7 +80,6 @@ class TestNameService(unittest.TestCase):
                 )
                 self.assertIsNone(message)
 
-        # Invalid names
         invalid_names_with_reasons = [
             ("", "Python package slug cannot be empty."),
             ("123package", "not a valid Python identifier"),
@@ -120,7 +107,6 @@ class TestNameService(unittest.TestCase):
 
     def test_pep503_name_ok(self):
         """Test PEP 503 project name validation."""
-        # Valid names
         valid_names = [
             "package-name",
             "Package_Name",
@@ -140,16 +126,12 @@ class TestNameService(unittest.TestCase):
                 )
                 self.assertIsNone(message)
 
-        # Invalid names
         invalid_names_with_reasons = [
-            ("-package", "violates PEP 503"),  # Starts with hyphen
-            ("package-", "violates PEP 503"),  # Ends with hyphen
-            ("pack***age", "violates PEP 503"),  # Contains invalid chars
-            ("package_name_with_too_many_underscores", "too long"),  # Too long
-            (
-                "with___too___many___underscores",
-                "too many underscores",
-            ),  # Too many underscores
+            ("-package", "violates PEP 503"),
+            ("package-", "violates PEP 503"),
+            ("pack***age", "violates PEP 503"),
+            ("package_name_with_too_many_underscores", "too long"),
+            ("with___too___many___underscores", "too many underscores"),
         ]
 
         for name, reason_fragment in invalid_names_with_reasons:

--- a/uv.lock
+++ b/uv.lock
@@ -162,6 +162,61 @@ wheels = [
 ]
 
 [[package]]
+name = "coverage"
+version = "7.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/4f/2251e65033ed2ce1e68f00f91a0294e0f80c80ae8c3ebbe2f12828c4cd53/coverage-7.8.0.tar.gz", hash = "sha256:7a3d62b3b03b4b6fd41a085f3574874cf946cb4604d2b4d3e8dca8cd570ca501", size = 811872, upload-time = "2025-03-30T20:36:45.376Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2b/77/074d201adb8383addae5784cb8e2dac60bb62bfdf28b2b10f3a3af2fda47/coverage-7.8.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:e7ac22a0bb2c7c49f441f7a6d46c9c80d96e56f5a8bc6972529ed43c8b694e27", size = 211493, upload-time = "2025-03-30T20:35:12.286Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/89/7a8efe585750fe59b48d09f871f0e0c028a7b10722b2172dfe021fa2fdd4/coverage-7.8.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:bf13d564d310c156d1c8e53877baf2993fb3073b2fc9f69790ca6a732eb4bfea", size = 211921, upload-time = "2025-03-30T20:35:14.18Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/ef/96a90c31d08a3f40c49dbe897df4f1fd51fb6583821a1a1c5ee30cc8f680/coverage-7.8.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a5761c70c017c1b0d21b0815a920ffb94a670c8d5d409d9b38857874c21f70d7", size = 244556, upload-time = "2025-03-30T20:35:15.616Z" },
+    { url = "https://files.pythonhosted.org/packages/89/97/dcd5c2ce72cee9d7b0ee8c89162c24972fb987a111b92d1a3d1d19100c61/coverage-7.8.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e5ff52d790c7e1628241ffbcaeb33e07d14b007b6eb00a19320c7b8a7024c040", size = 242245, upload-time = "2025-03-30T20:35:18.648Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/7b/b63cbb44096141ed435843bbb251558c8e05cc835c8da31ca6ffb26d44c0/coverage-7.8.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d39fc4817fd67b3915256af5dda75fd4ee10621a3d484524487e33416c6f3543", size = 244032, upload-time = "2025-03-30T20:35:20.131Z" },
+    { url = "https://files.pythonhosted.org/packages/97/e3/7fa8c2c00a1ef530c2a42fa5df25a6971391f92739d83d67a4ee6dcf7a02/coverage-7.8.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:b44674870709017e4b4036e3d0d6c17f06a0e6d4436422e0ad29b882c40697d2", size = 243679, upload-time = "2025-03-30T20:35:21.636Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/b3/e0a59d8df9150c8a0c0841d55d6568f0a9195692136c44f3d21f1842c8f6/coverage-7.8.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:8f99eb72bf27cbb167b636eb1726f590c00e1ad375002230607a844d9e9a2318", size = 241852, upload-time = "2025-03-30T20:35:23.525Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/82/db347ccd57bcef150c173df2ade97976a8367a3be7160e303e43dd0c795f/coverage-7.8.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b571bf5341ba8c6bc02e0baeaf3b061ab993bf372d982ae509807e7f112554e9", size = 242389, upload-time = "2025-03-30T20:35:25.09Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f6/3f7d7879ceb03923195d9ff294456241ed05815281f5254bc16ef71d6a20/coverage-7.8.0-cp311-cp311-win32.whl", hash = "sha256:e75a2ad7b647fd8046d58c3132d7eaf31b12d8a53c0e4b21fa9c4d23d6ee6d3c", size = 213997, upload-time = "2025-03-30T20:35:26.914Z" },
+    { url = "https://files.pythonhosted.org/packages/28/87/021189643e18ecf045dbe1e2071b2747901f229df302de01c998eeadf146/coverage-7.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:3043ba1c88b2139126fc72cb48574b90e2e0546d4c78b5299317f61b7f718b78", size = 214911, upload-time = "2025-03-30T20:35:28.498Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/12/4792669473297f7973518bec373a955e267deb4339286f882439b8535b39/coverage-7.8.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:bbb5cc845a0292e0c520656d19d7ce40e18d0e19b22cb3e0409135a575bf79fc", size = 211684, upload-time = "2025-03-30T20:35:29.959Z" },
+    { url = "https://files.pythonhosted.org/packages/be/e1/2a4ec273894000ebedd789e8f2fc3813fcaf486074f87fd1c5b2cb1c0a2b/coverage-7.8.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4dfd9a93db9e78666d178d4f08a5408aa3f2474ad4d0e0378ed5f2ef71640cb6", size = 211935, upload-time = "2025-03-30T20:35:31.912Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/3a/7b14f6e4372786709a361729164125f6b7caf4024ce02e596c4a69bccb89/coverage-7.8.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f017a61399f13aa6d1039f75cd467be388d157cd81f1a119b9d9a68ba6f2830d", size = 245994, upload-time = "2025-03-30T20:35:33.455Z" },
+    { url = "https://files.pythonhosted.org/packages/54/80/039cc7f1f81dcbd01ea796d36d3797e60c106077e31fd1f526b85337d6a1/coverage-7.8.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0915742f4c82208ebf47a2b154a5334155ed9ef9fe6190674b8a46c2fb89cb05", size = 242885, upload-time = "2025-03-30T20:35:35.354Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e0/dc8355f992b6cc2f9dcd5ef6242b62a3f73264893bc09fbb08bfcab18eb4/coverage-7.8.0-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8a40fcf208e021eb14b0fac6bdb045c0e0cab53105f93ba0d03fd934c956143a", size = 245142, upload-time = "2025-03-30T20:35:37.121Z" },
+    { url = "https://files.pythonhosted.org/packages/43/1b/33e313b22cf50f652becb94c6e7dae25d8f02e52e44db37a82de9ac357e8/coverage-7.8.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a1f406a8e0995d654b2ad87c62caf6befa767885301f3b8f6f73e6f3c31ec3a6", size = 244906, upload-time = "2025-03-30T20:35:39.07Z" },
+    { url = "https://files.pythonhosted.org/packages/05/08/c0a8048e942e7f918764ccc99503e2bccffba1c42568693ce6955860365e/coverage-7.8.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:77af0f6447a582fdc7de5e06fa3757a3ef87769fbb0fdbdeba78c23049140a47", size = 243124, upload-time = "2025-03-30T20:35:40.598Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/62/ea625b30623083c2aad645c9a6288ad9fc83d570f9adb913a2abdba562dd/coverage-7.8.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f2d32f95922927186c6dbc8bc60df0d186b6edb828d299ab10898ef3f40052fe", size = 244317, upload-time = "2025-03-30T20:35:42.204Z" },
+    { url = "https://files.pythonhosted.org/packages/62/cb/3871f13ee1130a6c8f020e2f71d9ed269e1e2124aa3374d2180ee451cee9/coverage-7.8.0-cp312-cp312-win32.whl", hash = "sha256:769773614e676f9d8e8a0980dd7740f09a6ea386d0f383db6821df07d0f08545", size = 214170, upload-time = "2025-03-30T20:35:44.216Z" },
+    { url = "https://files.pythonhosted.org/packages/88/26/69fe1193ab0bfa1eb7a7c0149a066123611baba029ebb448500abd8143f9/coverage-7.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:e5d2b9be5b0693cf21eb4ce0ec8d211efb43966f6657807f6859aab3814f946b", size = 214969, upload-time = "2025-03-30T20:35:45.797Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/21/87e9b97b568e223f3438d93072479c2f36cc9b3f6b9f7094b9d50232acc0/coverage-7.8.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5ac46d0c2dd5820ce93943a501ac5f6548ea81594777ca585bf002aa8854cacd", size = 211708, upload-time = "2025-03-30T20:35:47.417Z" },
+    { url = "https://files.pythonhosted.org/packages/75/be/882d08b28a0d19c9c4c2e8a1c6ebe1f79c9c839eb46d4fca3bd3b34562b9/coverage-7.8.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:771eb7587a0563ca5bb6f622b9ed7f9d07bd08900f7589b4febff05f469bea00", size = 211981, upload-time = "2025-03-30T20:35:49.002Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1d/ce99612ebd58082fbe3f8c66f6d8d5694976c76a0d474503fa70633ec77f/coverage-7.8.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42421e04069fb2cbcbca5a696c4050b84a43b05392679d4068acbe65449b5c64", size = 245495, upload-time = "2025-03-30T20:35:51.073Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/8d/6115abe97df98db6b2bd76aae395fcc941d039a7acd25f741312ced9a78f/coverage-7.8.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:554fec1199d93ab30adaa751db68acec2b41c5602ac944bb19187cb9a41a8067", size = 242538, upload-time = "2025-03-30T20:35:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/74/2f8cc196643b15bc096d60e073691dadb3dca48418f08bc78dd6e899383e/coverage-7.8.0-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5aaeb00761f985007b38cf463b1d160a14a22c34eb3f6a39d9ad6fc27cb73008", size = 244561, upload-time = "2025-03-30T20:35:54.658Z" },
+    { url = "https://files.pythonhosted.org/packages/22/70/c10c77cd77970ac965734fe3419f2c98665f6e982744a9bfb0e749d298f4/coverage-7.8.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:581a40c7b94921fffd6457ffe532259813fc68eb2bdda60fa8cc343414ce3733", size = 244633, upload-time = "2025-03-30T20:35:56.221Z" },
+    { url = "https://files.pythonhosted.org/packages/38/5a/4f7569d946a07c952688debee18c2bb9ab24f88027e3d71fd25dbc2f9dca/coverage-7.8.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:f319bae0321bc838e205bf9e5bc28f0a3165f30c203b610f17ab5552cff90323", size = 242712, upload-time = "2025-03-30T20:35:57.801Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/a1/03a43b33f50475a632a91ea8c127f7e35e53786dbe6781c25f19fd5a65f8/coverage-7.8.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:04bfec25a8ef1c5f41f5e7e5c842f6b615599ca8ba8391ec33a9290d9d2db3a3", size = 244000, upload-time = "2025-03-30T20:35:59.378Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/89/ab6c43b1788a3128e4d1b7b54214548dcad75a621f9d277b14d16a80d8a1/coverage-7.8.0-cp313-cp313-win32.whl", hash = "sha256:dd19608788b50eed889e13a5d71d832edc34fc9dfce606f66e8f9f917eef910d", size = 214195, upload-time = "2025-03-30T20:36:01.005Z" },
+    { url = "https://files.pythonhosted.org/packages/12/12/6bf5f9a8b063d116bac536a7fb594fc35cb04981654cccb4bbfea5dcdfa0/coverage-7.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:a9abbccd778d98e9c7e85038e35e91e67f5b520776781d9a1e2ee9d400869487", size = 214998, upload-time = "2025-03-30T20:36:03.006Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/e6/1e9df74ef7a1c983a9c7443dac8aac37a46f1939ae3499424622e72a6f78/coverage-7.8.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:18c5ae6d061ad5b3e7eef4363fb27a0576012a7447af48be6c75b88494c6cf25", size = 212541, upload-time = "2025-03-30T20:36:04.638Z" },
+    { url = "https://files.pythonhosted.org/packages/04/51/c32174edb7ee49744e2e81c4b1414ac9df3dacfcb5b5f273b7f285ad43f6/coverage-7.8.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:95aa6ae391a22bbbce1b77ddac846c98c5473de0372ba5c463480043a07bff42", size = 212767, upload-time = "2025-03-30T20:36:06.503Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/8f/f454cbdb5212f13f29d4a7983db69169f1937e869a5142bce983ded52162/coverage-7.8.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e013b07ba1c748dacc2a80e69a46286ff145935f260eb8c72df7185bf048f502", size = 256997, upload-time = "2025-03-30T20:36:08.137Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/74/2bf9e78b321216d6ee90a81e5c22f912fc428442c830c4077b4a071db66f/coverage-7.8.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d766a4f0e5aa1ba056ec3496243150698dc0481902e2b8559314368717be82b1", size = 252708, upload-time = "2025-03-30T20:36:09.781Z" },
+    { url = "https://files.pythonhosted.org/packages/92/4d/50d7eb1e9a6062bee6e2f92e78b0998848a972e9afad349b6cdde6fa9e32/coverage-7.8.0-cp313-cp313t-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ad80e6b4a0c3cb6f10f29ae4c60e991f424e6b14219d46f1e7d442b938ee68a4", size = 255046, upload-time = "2025-03-30T20:36:11.409Z" },
+    { url = "https://files.pythonhosted.org/packages/40/9e/71fb4e7402a07c4198ab44fc564d09d7d0ffca46a9fb7b0a7b929e7641bd/coverage-7.8.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:b87eb6fc9e1bb8f98892a2458781348fa37e6925f35bb6ceb9d4afd54ba36c73", size = 256139, upload-time = "2025-03-30T20:36:13.86Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1a/78d37f7a42b5beff027e807c2843185961fdae7fe23aad5a4837c93f9d25/coverage-7.8.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:d1ba00ae33be84066cfbe7361d4e04dec78445b2b88bdb734d0d1cbab916025a", size = 254307, upload-time = "2025-03-30T20:36:16.074Z" },
+    { url = "https://files.pythonhosted.org/packages/58/e9/8fb8e0ff6bef5e170ee19d59ca694f9001b2ec085dc99b4f65c128bb3f9a/coverage-7.8.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:f3c38e4e5ccbdc9198aecc766cedbb134b2d89bf64533973678dfcf07effd883", size = 255116, upload-time = "2025-03-30T20:36:18.033Z" },
+    { url = "https://files.pythonhosted.org/packages/56/b0/d968ecdbe6fe0a863de7169bbe9e8a476868959f3af24981f6a10d2b6924/coverage-7.8.0-cp313-cp313t-win32.whl", hash = "sha256:379fe315e206b14e21db5240f89dc0774bdd3e25c3c58c2c733c99eca96f1ada", size = 214909, upload-time = "2025-03-30T20:36:19.644Z" },
+    { url = "https://files.pythonhosted.org/packages/87/e9/d6b7ef9fecf42dfb418d93544af47c940aa83056c49e6021a564aafbc91f/coverage-7.8.0-cp313-cp313t-win_amd64.whl", hash = "sha256:2e4b6b87bb0c846a9315e3ab4be2d52fac905100565f4b92f02c445c8799e257", size = 216068, upload-time = "2025-03-30T20:36:21.282Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/f1/1da77bb4c920aa30e82fa9b6ea065da3467977c2e5e032e38e66f1c57ffd/coverage-7.8.0-pp39.pp310.pp311-none-any.whl", hash = "sha256:b8194fb8e50d556d5849753de991d390c5a1edeeba50f68e3a9253fbd8bf8ccd", size = 203443, upload-time = "2025-03-30T20:36:41.959Z" },
+    { url = "https://files.pythonhosted.org/packages/59/f1/4da7717f0063a222db253e7121bd6a56f6fb1ba439dcc36659088793347c/coverage-7.8.0-py3-none-any.whl", hash = "sha256:dbf364b4c5e7bae9250528167dfe40219b62e2d573c854d74be213e1e52069f7", size = 203435, upload-time = "2025-03-30T20:36:43.61Z" },
+]
+
+[package.optional-dependencies]
+toml = [
+    { name = "tomli", marker = "python_full_version <= '3.11'" },
+]
+
+[[package]]
 name = "cryptography"
 version = "44.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -543,6 +598,7 @@ dev = [
     { name = "hatchling" },
     { name = "pylint" },
     { name = "pytest" },
+    { name = "pytest-cov" },
     { name = "ruff" },
     { name = "uv" },
 ]
@@ -560,6 +616,7 @@ dev = [
     { name = "hatchling", specifier = ">=1.27.0" },
     { name = "pylint", specifier = ">=3.3.7" },
     { name = "pytest", specifier = ">=8.3.5" },
+    { name = "pytest-cov", specifier = ">=6.1.1" },
     { name = "ruff", specifier = ">=0.11.9" },
     { name = "uv", specifier = ">=0.7.3" },
 ]
@@ -595,6 +652,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ae/3c/c9d525a414d506893f0cd8a8d0de7706446213181570cdbd766691164e40/pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845", size = 1450891, upload-time = "2025-03-02T12:54:54.503Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/30/3d/64ad57c803f1fa1e963a7946b6e0fea4a70df53c1a7fed304586539c2bac/pytest-8.3.5-py3-none-any.whl", hash = "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820", size = 343634, upload-time = "2025-03-02T12:54:52.069Z" },
+]
+
+[[package]]
+name = "pytest-cov"
+version = "6.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage", extra = ["toml"] },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/25/69/5f1e57f6c5a39f81411b550027bf72842c4567ff5fd572bed1edc9e4b5d9/pytest_cov-6.1.1.tar.gz", hash = "sha256:46935f7aaefba760e716c2ebfbe1c216240b9592966e7da99ea8292d4d3e2a0a", size = 66857, upload-time = "2025-04-05T14:07:51.592Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/28/d0/def53b4a790cfb21483016430ed828f64830dd981ebe1089971cd10cab25/pytest_cov-6.1.1-py3-none-any.whl", hash = "sha256:bddf29ed2d0ab6f4df17b4c55b0a657287db8684af9c42ea546b21b1041b3dde", size = 23841, upload-time = "2025-04-05T14:07:49.641Z" },
 ]
 
 [[package]]
@@ -697,6 +767,45 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/87/302344fed471e44a87289cf4967697d07e532f2421fdaf868a303cbae4ff/tomli-2.2.1.tar.gz", hash = "sha256:cd45e1dc79c835ce60f7404ec8119f2eb06d38b1deba146f07ced3bbc44505ff", size = 17175, upload-time = "2024-11-27T22:38:36.873Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/ca/75707e6efa2b37c77dadb324ae7d9571cb424e61ea73fad7c56c2d14527f/tomli-2.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:678e4fa69e4575eb77d103de3df8a895e1591b48e740211bd1067378c69e8249", size = 131077, upload-time = "2024-11-27T22:37:54.956Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/16/51ae563a8615d472fdbffc43a3f3d46588c264ac4f024f63f01283becfbb/tomli-2.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:023aa114dd824ade0100497eb2318602af309e5a55595f76b626d6d9f3b7b0a6", size = 123429, upload-time = "2024-11-27T22:37:56.698Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/dd/4f6cd1e7b160041db83c694abc78e100473c15d54620083dbd5aae7b990e/tomli-2.2.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ece47d672db52ac607a3d9599a9d48dcb2f2f735c6c2d1f34130085bb12b112a", size = 226067, upload-time = "2024-11-27T22:37:57.63Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/6b/c54ede5dc70d648cc6361eaf429304b02f2871a345bbdd51e993d6cdf550/tomli-2.2.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6972ca9c9cc9f0acaa56a8ca1ff51e7af152a9f87fb64623e31d5c83700080ee", size = 236030, upload-time = "2024-11-27T22:37:59.344Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/47/999514fa49cfaf7a92c805a86c3c43f4215621855d151b61c602abb38091/tomli-2.2.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c954d2250168d28797dd4e3ac5cf812a406cd5a92674ee4c8f123c889786aa8e", size = 240898, upload-time = "2024-11-27T22:38:00.429Z" },
+    { url = "https://files.pythonhosted.org/packages/73/41/0a01279a7ae09ee1573b423318e7934674ce06eb33f50936655071d81a24/tomli-2.2.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8dd28b3e155b80f4d54beb40a441d366adcfe740969820caf156c019fb5c7ec4", size = 229894, upload-time = "2024-11-27T22:38:02.094Z" },
+    { url = "https://files.pythonhosted.org/packages/55/18/5d8bc5b0a0362311ce4d18830a5d28943667599a60d20118074ea1b01bb7/tomli-2.2.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:e59e304978767a54663af13c07b3d1af22ddee3bb2fb0618ca1593e4f593a106", size = 245319, upload-time = "2024-11-27T22:38:03.206Z" },
+    { url = "https://files.pythonhosted.org/packages/92/a3/7ade0576d17f3cdf5ff44d61390d4b3febb8a9fc2b480c75c47ea048c646/tomli-2.2.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:33580bccab0338d00994d7f16f4c4ec25b776af3ffaac1ed74e0b3fc95e885a8", size = 238273, upload-time = "2024-11-27T22:38:04.217Z" },
+    { url = "https://files.pythonhosted.org/packages/72/6f/fa64ef058ac1446a1e51110c375339b3ec6be245af9d14c87c4a6412dd32/tomli-2.2.1-cp311-cp311-win32.whl", hash = "sha256:465af0e0875402f1d226519c9904f37254b3045fc5084697cefb9bdde1ff99ff", size = 98310, upload-time = "2024-11-27T22:38:05.908Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1c/4a2dcde4a51b81be3530565e92eda625d94dafb46dbeb15069df4caffc34/tomli-2.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:2d0f2fdd22b02c6d81637a3c95f8cd77f995846af7414c5c4b8d0545afa1bc4b", size = 108309, upload-time = "2024-11-27T22:38:06.812Z" },
+    { url = "https://files.pythonhosted.org/packages/52/e1/f8af4c2fcde17500422858155aeb0d7e93477a0d59a98e56cbfe75070fd0/tomli-2.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4a8f6e44de52d5e6c657c9fe83b562f5f4256d8ebbfe4ff922c495620a7f6cea", size = 132762, upload-time = "2024-11-27T22:38:07.731Z" },
+    { url = "https://files.pythonhosted.org/packages/03/b8/152c68bb84fc00396b83e7bbddd5ec0bd3dd409db4195e2a9b3e398ad2e3/tomli-2.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8d57ca8095a641b8237d5b079147646153d22552f1c637fd3ba7f4b0b29167a8", size = 123453, upload-time = "2024-11-27T22:38:09.384Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/d6/fc9267af9166f79ac528ff7e8c55c8181ded34eb4b0e93daa767b8841573/tomli-2.2.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4e340144ad7ae1533cb897d406382b4b6fede8890a03738ff1683af800d54192", size = 233486, upload-time = "2024-11-27T22:38:10.329Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/51/51c3f2884d7bab89af25f678447ea7d297b53b5a3b5730a7cb2ef6069f07/tomli-2.2.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:db2b95f9de79181805df90bedc5a5ab4c165e6ec3fe99f970d0e302f384ad222", size = 242349, upload-time = "2024-11-27T22:38:11.443Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/df/bfa89627d13a5cc22402e441e8a931ef2108403db390ff3345c05253935e/tomli-2.2.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:40741994320b232529c802f8bc86da4e1aa9f413db394617b9a256ae0f9a7f77", size = 252159, upload-time = "2024-11-27T22:38:13.099Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/6e/fa2b916dced65763a5168c6ccb91066f7639bdc88b48adda990db10c8c0b/tomli-2.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:400e720fe168c0f8521520190686ef8ef033fb19fc493da09779e592861b78c6", size = 237243, upload-time = "2024-11-27T22:38:14.766Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/04/885d3b1f650e1153cbb93a6a9782c58a972b94ea4483ae4ac5cedd5e4a09/tomli-2.2.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:02abe224de6ae62c19f090f68da4e27b10af2b93213d36cf44e6e1c5abd19fdd", size = 259645, upload-time = "2024-11-27T22:38:15.843Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/de/6b432d66e986e501586da298e28ebeefd3edc2c780f3ad73d22566034239/tomli-2.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b82ebccc8c8a36f2094e969560a1b836758481f3dc360ce9a3277c65f374285e", size = 244584, upload-time = "2024-11-27T22:38:17.645Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/9a/47c0449b98e6e7d1be6cbac02f93dd79003234ddc4aaab6ba07a9a7482e2/tomli-2.2.1-cp312-cp312-win32.whl", hash = "sha256:889f80ef92701b9dbb224e49ec87c645ce5df3fa2cc548664eb8a25e03127a98", size = 98875, upload-time = "2024-11-27T22:38:19.159Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/60/9b9638f081c6f1261e2688bd487625cd1e660d0a85bd469e91d8db969734/tomli-2.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:7fc04e92e1d624a4a63c76474610238576942d6b8950a2d7f908a340494e67e4", size = 109418, upload-time = "2024-11-27T22:38:20.064Z" },
+    { url = "https://files.pythonhosted.org/packages/04/90/2ee5f2e0362cb8a0b6499dc44f4d7d48f8fff06d28ba46e6f1eaa61a1388/tomli-2.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f4039b9cbc3048b2416cc57ab3bda989a6fcf9b36cf8937f01a6e731b64f80d7", size = 132708, upload-time = "2024-11-27T22:38:21.659Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/ec/46b4108816de6b385141f082ba99e315501ccd0a2ea23db4a100dd3990ea/tomli-2.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:286f0ca2ffeeb5b9bd4fcc8d6c330534323ec51b2f52da063b11c502da16f30c", size = 123582, upload-time = "2024-11-27T22:38:22.693Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/bd/b470466d0137b37b68d24556c38a0cc819e8febe392d5b199dcd7f578365/tomli-2.2.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a92ef1a44547e894e2a17d24e7557a5e85a9e1d0048b0b5e7541f76c5032cb13", size = 232543, upload-time = "2024-11-27T22:38:24.367Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/e5/82e80ff3b751373f7cead2815bcbe2d51c895b3c990686741a8e56ec42ab/tomli-2.2.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9316dc65bed1684c9a98ee68759ceaed29d229e985297003e494aa825ebb0281", size = 241691, upload-time = "2024-11-27T22:38:26.081Z" },
+    { url = "https://files.pythonhosted.org/packages/05/7e/2a110bc2713557d6a1bfb06af23dd01e7dde52b6ee7dadc589868f9abfac/tomli-2.2.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e85e99945e688e32d5a35c1ff38ed0b3f41f43fad8df0bdf79f72b2ba7bc5272", size = 251170, upload-time = "2024-11-27T22:38:27.921Z" },
+    { url = "https://files.pythonhosted.org/packages/64/7b/22d713946efe00e0adbcdfd6d1aa119ae03fd0b60ebed51ebb3fa9f5a2e5/tomli-2.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ac065718db92ca818f8d6141b5f66369833d4a80a9d74435a268c52bdfa73140", size = 236530, upload-time = "2024-11-27T22:38:29.591Z" },
+    { url = "https://files.pythonhosted.org/packages/38/31/3a76f67da4b0cf37b742ca76beaf819dca0ebef26d78fc794a576e08accf/tomli-2.2.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:d920f33822747519673ee656a4b6ac33e382eca9d331c87770faa3eef562aeb2", size = 258666, upload-time = "2024-11-27T22:38:30.639Z" },
+    { url = "https://files.pythonhosted.org/packages/07/10/5af1293da642aded87e8a988753945d0cf7e00a9452d3911dd3bb354c9e2/tomli-2.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a198f10c4d1b1375d7687bc25294306e551bf1abfa4eace6650070a5c1ae2744", size = 243954, upload-time = "2024-11-27T22:38:31.702Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/b9/1ed31d167be802da0fc95020d04cd27b7d7065cc6fbefdd2f9186f60d7bd/tomli-2.2.1-cp313-cp313-win32.whl", hash = "sha256:d3f5614314d758649ab2ab3a62d4f2004c825922f9e370b29416484086b264ec", size = 98724, upload-time = "2024-11-27T22:38:32.837Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/32/b0963458706accd9afcfeb867c0f9175a741bf7b19cd424230714d722198/tomli-2.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:a38aa0308e754b0e3c67e344754dff64999ff9b513e691d0e786265c93583c69", size = 109383, upload-time = "2024-11-27T22:38:34.455Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/c2/61d3e0f47e2b74ef40a68b9e6ad5984f6241a942f7cd3bbfbdbd03861ea9/tomli-2.2.1-py3-none-any.whl", hash = "sha256:cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc", size = 14257, upload-time = "2024-11-27T22:38:35.385Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Cleanup, Code Coverage in CI/CD, and Version Bump

## 1. Summary

The main goal of these changes is to enhance our testing strategy by adding code coverage analysis. Such analysis helps ensure that our tests adequately cover the codebase and identifies areas that may require more testing. Key changes include:

*   Addition of `pytest-cov` as a development dependency.
*   Introduction of a `Makefile` with targets for testing, coverage reporting (terminal and HTML), and bootstrapping.
*   Integration of coverage reporting into the GitHub Actions CI workflow.
*   Updates to VS Code tasks to use Makefile targets.
*   Documentation updates regarding the new testing and coverage procedures.
*   Minor code cleanup (mostly comment removal) and a version bump.

## 2. Files Changed

*   **`.github/workflows/tests.yml`**: Modified
    *   Added a new step, "Run test coverage," which executes `make coverage`.
*   **`.ruff.toml`**: Deleted
    *   This file, which previously selected only the `BLE001` Ruff rule and contained example Python code, has been removed. Ruff will now use its default rules or configuration specified elsewhere (e.g., in `pyproject.toml`, though not explicitly configured in this PR's diff for `pyproject.toml`). This simplifies the Ruff setup.
*   **`.vscode/tasks.json`**: Modified
    *   The "Run Test Suite" task now uses `make test`.
    *   A new task, "Run Test Coverage," has been added, which executes `make coverage`.
*   **`Makefile`**: Added
    *   A new Makefile providing convenience targets:
        *   `bootstrap`: Re-creates the virtual environment and installs dependencies.
        *   `test`: Runs the test suite using `pytest -v`.
        *   `coverage`: Runs tests with coverage, reports to the terminal, and fails if coverage is below 80%.
        *   `coverage-html`: Generates an HTML coverage report.
*   **`docs/coding-standards.md`**: Modified
    *   Minor formatting adjustment in a Python code block example (indentation of the code block itself).
*   **`docs/contributing.md`**: Modified
    *   Updated instructions for testing changes to use `make test` and `make coverage`.
    *   Added information on how to generate and view the HTML coverage report using `make coverage-html`.
*   **`docs/tech_stack.md`**: Modified
    *   Updated author names in the change log from "Kayvan" to "Kayvan Sylvan".
*   **`docs/testing-strategy.md`**: Modified
    *   Added a new objective: "Test coverage should be at least 80%".
    *   Added a new subsection "2.4 Test Coverage" detailing the use of `pytest-cov`, its integration in CI, and the minimum coverage target.
    *   Updated the change log.
*   **`pyproject.toml`**: Modified
    *   Added `pytest-cov>=6.1.1` to the `[dependency-groups.dev]` list.
    *   Removed a commented-out section `[tool.hatch.build.targets.wheel.shared-scripts]`.
*   **`src/pyhatchery/__about__.py`**: Modified
    *   Incremented `__version__` from `"0.6.0"` to `"0.6.1"`.
    *   Changed module docstring from single quotes to triple double quotes.
*   **`src/pyhatchery/cli.py`**: Modified
    *   Removed several inline comments that were deemed unnecessary or redundant, improving code readability.
*   **`src/pyhatchery/components/config_loader.py`**: Modified
    *   Removed explanatory comments about `dotenv_values`.
*   **`src/pyhatchery/components/http_client.py`**: Modified
    *   Removed a comment related to example usage.
*   **`src/pyhatchery/components/interactive_wizard.py`**: Modified
    *   Removed comments related to predefined choices and example usage.
*   **`src/pyhatchery/components/name_service.py`**: Modified
    *   Removed comments explaining normalization steps and slug derivation logic.
*   **`tests/integration/test_project_generation.py`**: Modified
    *   Removed some comments explaining test setup and command execution.
*   **`tests/test_version.py`**: Modified
    *   Removed a comment explaining the SemVer regex.
*   **`tests/unit/components/test_config_loader.py`**: Modified
    *   Removed comments and minor refactoring in test setup.
*   **`tests/unit/components/test_http_client.py`**: Modified
    *   Removed comments detailing test setup, execution, and assertions.
*   **`tests/unit/components/test_interactive_wizard.py`**: Modified
    *   Removed comments related to test logic and mock assertions.
*   **`tests/unit/components/test_name_service.py`**: Modified
    *   Removed comments categorizing valid/invalid test cases.
*   **`tests/unit/test_cli.py`**: Modified
    *   Removed comments explaining test setup and CLI execution logic.
*   **`uv.lock`**: Modified
    *   Updated to include `coverage` and `pytest-cov` packages and their dependencies (like `tomli`).

## 3. Code Changes

Key code changes include:

*   **Makefile**:
    ```makefile
    .PHONY: bootstrap test coverage coverage-html

    COVERAGE_FAIL_UNDER := 80
    COVERAGE_SRC := src/pyhatchery

    test:
        uv run pytest -v

    coverage:
        uv run pytest -v --cov=$(COVERAGE_SRC) \
            -ra -q \
            --cov-report=term-missing \
            --cov-fail-under=$(COVERAGE_FAIL_UNDER)

    coverage-html:
        uv run pytest --cov=$(COVERAGE_SRC) \
            --cov-report=html:coverage_html \
            --cov-fail-under=$(COVERAGE_FAIL_UNDER)
    ```
    This introduces standardized commands for testing and coverage.

*   **CI Workflow (`.github/workflows/tests.yml`)**:
    ```yaml
          - name: Run test coverage
            run: make coverage
    ```
    Ensures coverage is checked on every push/PR.

*   **Dependencies (`pyproject.toml`)**:
    ```toml
    [dependency-groups]
    dev = [
        # ... other dependencies
        "pytest-cov>=6.1.1",
        # ...
    ]
    ```
    Adds `pytest-cov` for coverage analysis.

*   **Version Bump (`src/pyhatchery/__about__.py`)**:
    ```python
    __version__ = "0.6.1"
    ```

*   **Code Cleanup**: Numerous files saw removal of comments, aiming for cleaner and more self-documenting code where possible. For example, in `src/pyhatchery/cli.py`:
    ```diff
    -    # Note: We don't check pep503_name_ok here, as it's done earlier as a blocking check
    -
    -    # Check PyPI availability
         is_pypi_taken, pypi_error_msg = check_pypi_availability(pypi_slug)
    ```

## 4. Reason for Changes

*   **Improve Code Quality**: Implementing test coverage helps us understand how much of our code is executed during tests, highlighting untested parts and guiding efforts to improve test thoroughness.
*   **Enhance Developer Experience**: The `Makefile` provides simple, memorable commands for common development tasks like running tests and generating coverage reports. VS Code task updates align with this.
*   **CI Enforcement**: Integrating coverage checks into the CI pipeline ensures that new code contributions maintain or improve test coverage and automatically fails builds if coverage drops below the defined threshold (currently 80%).
*   **Maintainability**: Removing redundant comments and minor refactorings contribute to cleaner, more maintainable code.
*   **Documentation**: Keeping documentation up-to-date with current practices is crucial for contributors.

## 5. Impact of Changes

*   **Improved Test Quality**: Developers will be more aware of untested code paths, leading to better test writing and higher overall code quality.
*   **Standardized Development Workflow**: The `Makefile` and updated VS Code tasks streamline local development.
*   **CI Reliability**: The CI pipeline now provides an additional quality gate by checking for test coverage.
*   **Potential Bugs**: No direct bug fixes are part of this PR, but improved testing practices may help prevent future bugs. No new potential bugs are immediately apparent from these changes, as they primarily affect the testing and CI infrastructure. The removal of `.ruff.toml` might change linting behavior if its previous specific rule (`BLE001`) is not covered by the default/new Ruff configuration, but this is a linting concern rather than a runtime bug.

## 6. Test Plan

*   **CI Pipeline**: The GitHub Actions workflow (`tests.yml`) has been updated to include a coverage run. This will be automatically tested when this PR is pushed.
    *   `make coverage` will be executed, which includes `pytest --cov-fail-under=80`.
*   **Local Testing**: Developers should pull these changes and can test the new Makefile targets:
    *   Run `make test` to execute the test suite.
    *   Run `make coverage` to run tests with coverage and see the terminal report.
    *   Run `make coverage-html` to generate an HTML report in `./coverage_html/index.html` for detailed inspection.
*   All existing tests are expected to pass, and the coverage report should be generated successfully.

## 7. Additional Notes

*   The project version has been bumped to `0.6.1` to reflect these enhancements.
*   The deletion of `.ruff.toml` simplifies Ruff configuration, relying on defaults or project-wide settings. Developers should ensure that the linting behavior remains as expected.
*   The numerous comment removals across the codebase are intended as cleanup and should not affect functionality.
