### PR TITLE
Increase Test Coverage Requirement and Update Click Dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 
 .PHONY: help bootstrap test coverage coverage-html format
 
-COVERAGE_FAIL_UNDER := 80
+COVERAGE_FAIL_UNDER := 85
 COVERAGE_SRC := src/pyhatchery
 
 help:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
-dependencies = ["click>=8.1.8", "python-dotenv>=1.1.0", "requests>=2.32.3"]
+dependencies = ["click>=8.2.0", "python-dotenv>=1.1.0", "requests>=2.32.3"]
 
 [project.urls]
 "Homepage" = "https://github.com/ksylvan/pyhatchery"

--- a/src/pyhatchery/__about__.py
+++ b/src/pyhatchery/__about__.py
@@ -1,3 +1,3 @@
 """Version information for pyhatchery."""
 
-__version__ = "0.7.2"
+__version__ = "0.7.3"

--- a/uv.lock
+++ b/uv.lock
@@ -142,14 +142,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.1.8"
+version = "8.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593, upload-time = "2024-12-21T18:38:44.339Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/0f/62ca20172d4f87d93cf89665fbaedcd560ac48b465bd1d92bfc7ea6b0a41/click-8.2.0.tar.gz", hash = "sha256:f5452aeddd9988eefa20f90f05ab66f17fce1ee2a36907fd30b05bbb5953814d", size = 235857, upload-time = "2025-05-10T22:21:03.111Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2", size = 98188, upload-time = "2024-12-21T18:38:41.666Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/58/1f37bf81e3c689cc74ffa42102fa8915b59085f54a6e4a80bc6265c0f6bf/click-8.2.0-py3-none-any.whl", hash = "sha256:6b303f0b2aa85f1cb4e5303078fadcbcd4e476f114fab9b5007005711839325c", size = 102156, upload-time = "2025-05-10T22:21:01.352Z" },
 ]
 
 [[package]]
@@ -605,7 +605,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "click", specifier = ">=8.1.8" },
+    { name = "click", specifier = ">=8.2.0" },
     { name = "python-dotenv", specifier = ">=1.1.0" },
     { name = "requests", specifier = ">=2.32.3" },
 ]


### PR DESCRIPTION
# Increase Test Coverage Requirement and Update Click Dependency

## Summary
This PR makes two key changes to the project:
1. Increases the minimum test coverage requirement from 80% to 85%
2. Updates the Click dependency from 8.1.8 to 8.2.0

## Files Changed

### Makefile
- Increased the `COVERAGE_FAIL_UNDER` threshold from 80% to 85%, requiring more comprehensive test coverage for the codebase.

```diff
-COVERAGE_FAIL_UNDER := 80
+COVERAGE_FAIL_UNDER := 85
```

### pyproject.toml
- Updated the Click dependency requirement from version 8.1.8 to 8.2.0.

```diff
-dependencies = ["click>=8.1.8", "python-dotenv>=1.1.0", "requests>=2.32.3"]
+dependencies = ["click>=8.2.0", "python-dotenv>=1.1.0", "requests>=2.32.3"]
```

### uv.lock
- Updated the Click package version from 8.1.8 to 8.2.0 in the lockfile
- Updated the corresponding hashes, URLs, and file sizes for both the source distribution and wheel
- Updated the dependency specification in the package metadata section

## Reason for Changes

### Test Coverage Increase
The increase in test coverage requirement from 80% to 85% aims to improve code quality and reliability by ensuring more comprehensive testing of the codebase. This change promotes better test practices and reduces the likelihood of undiscovered bugs.

### Click Dependency Update
The Click library update to version 8.2.0 provides access to the latest features, bug fixes, and security improvements in this command-line interface toolkit. The update ensures the project stays current with the ecosystem's best practices and capabilities.

## Impact of Changes

### Test Coverage
- Existing tests may need to be expanded to meet the new 85% coverage threshold
- Developers will need to ensure new code contributions maintain this higher standard
- The CI pipeline will fail if coverage drops below 85%, enforcing this quality standard

### Click Dependency
- The Click update is a minor version bump (8.1.8 to 8.2.0), suggesting backward compatibility
- The new version includes updated wheel and source distribution packages
- The file size increase (98KB to 102KB for the wheel, 226KB to 235KB for the source) indicates new features or improvements

## Test Plan
- Run the test suite with coverage reporting to verify it meets the new 85% threshold
- Test CLI functionality to ensure compatibility with the updated Click version
- Verify that the CI pipeline passes with the new requirements

## Additional Notes
- The Click update appears to be from a future release (upload date shown as 2025-05-10), which may be a timestamp error in the lockfile or potentially a pre-release version
- No other dependencies were modified in this update
